### PR TITLE
Fix typo by adding ternary statement to ejs template

### DIFF
--- a/views/todos.ejs
+++ b/views/todos.ejs
@@ -18,7 +18,8 @@
     <% }) %>    
     </ul>
 
-    <h2><%= user.userName %> has <%= left %> things left to do.</h2>
+    <%# Ternary checks the value of left to determine if word should be pluralized %>
+    <h2><%= user.userName %> has <%= left %> <%= (left === 1) ? "thing" : "things" %> left to do.</h2>
 
     <form action="/todos/createTodo" method='POST'>
         <input type="text" placeholder="Enter Todo Item" name='todoItem'>


### PR DESCRIPTION
This small change allows us to differentiate between 1 thing left and multiple things left. For instance, the todos view page will now render "User has 1 thing left to do" instead of "User has 1 things left to do."

The page still renders "User has 2 things left to do" and "User has 0 things left to do."