### PR TITLE
Update starter files to prevent leaking dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode/*
+.env

--- a/config/.env
+++ b/config/.env
@@ -1,2 +1,0 @@
-PORT = 2121
-DB_STRING = mongodb+srv://demo:demo@cluster0.hcds1.mongodb.net/todos?retryWrites=true&w=majority


### PR DESCRIPTION
Remove dotenv file and add the file to the gitignore in order to prevent anyone who forks the repository from leaking their dotenv file. If you simply add the dotenv file to the gitignore as stated in the readme, it will not work unless you delete the original dotenv file first. 